### PR TITLE
Update develop Editor to 17.x-2026-06-19

### DIFF
--- a/docs/guides/developer/docs/participate/infrastructure/index.md
+++ b/docs/guides/developer/docs/participate/infrastructure/index.md
@@ -18,19 +18,10 @@ Technische Universität Ilmenau | legacy.opencast.org           | Lars Kiesow   
 ### CI Servers
 Institution                | Hostname                             | Admin (Software) | Admin (Hardware)
 ---------------------------|--------------------------------------|------------------|--------------------
-University of Cologne      | oc-com-admin.rrz.uni-koeln.de        | Greg Logan       | Ruth Lang
-University of Cologne      | oc-com-worker1.rrz.uni-koeln.de      | Greg Logan       | Ruth Lang
-University of Cologne      | oc-com-presentation.rrz.uni-koeln.de | Greg Logan       | Ruth Lang
-
+Logan IT Enterprises       | ci.opencast.org                      | Greg Logan       | Greg Logan
 
 
 ### Maven Repository
-
-Institution                | Hostname                      | Admin (Software) | Admin (Hardware)  | Notes
----------------------------|-------------------------------|------------------|-------------------|-----------------
-Harvard DCE                | mvncache.opencast.org         | Lars Kiesow      | DCE Devel group   | Nginx cache, AWS
-University of Osnabrück    | nexus.opencast.org            | Lars Kiesow      | Lars Kiesow       | nexus-oss
-
 Nexus administration:
 
 - Greg Logan
@@ -42,9 +33,7 @@ Nexus administration:
 Institution                | Hostname                        | Admin (Software) | Admin (Hardware)
 ---------------------------|---------------------------------|------------------|-------------------------
 University of Osnabrück    | pkg.opencast.org                | Lars Kiesow      | Lars Kiesow
-University of Cologne      | ci.opencast.org                 | Greg Logan       | Ruth Lang
 University of Osnabrück    | docs.opencast.org               | Lars Kiesow      | Lars Kiesow
-University of Stuttgart    | testrailoc.tik.uni-stuttgart.de | Release managers | Per Pascal Grube
 
 
 Administrators
@@ -99,11 +88,5 @@ order:
 
 Other services and the primary contact for them:
 
-- Google
-    - Greg Logan
 - YouTube
     - Greg Logan and ETH Staff
-- Twitter
-    - Lars Kiesow
-- Facebook
-    - Rüdiger Rolf

--- a/docs/guides/developer/docs/participate/infrastructure/index.md
+++ b/docs/guides/developer/docs/participate/infrastructure/index.md
@@ -47,6 +47,7 @@ tools.  These tools are
 - GitHub
 - Google Groups
 - Crowdin
+- Google Drive
 
 While many of our administrators are committers, an administrator is _not_ a committer by necessity.  Administrators
 have important responsibilities within the community, but mainly work behind the scenes.  These responsibilities
@@ -65,7 +66,7 @@ groups in multiple places when a change is necessary.  These changes are
 - Modifying the [GitHub committers group](https://github.com/orgs/opencast/teams/committers/members) upon request
 - Modifying the [Google committers group](https://admin.google.com/opencast.org/AdminHome?hl=de&pli=1&fral=1&groupId=committers@opencast.org&chromeless=1#OGX:Group?hl=de)
 - Modifying the [Crowdin committers group](https://crowdin.com/project/opencast-community/settings#members)
-- Modifying the list of committers on the [Opencast website](https://opencast.org/people)
+- Modifying the committer storage permissions in the admin google drive space
 
 ### Current Administrators
 

--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/opencast/opencast-editor/releases/download/17.x-2025-05-23/oc-editor-17.x-2025-05-23.tar.gz</editor.url>
-    <editor.sha256></editor.sha256>
+    <editor.url>https://github.com/gregorydlogan/opencast-editor/releases/download/17.x-2026-06-19/oc-editor-17.x-2026-06-19.tar.gz</editor.url>
+    <editor.sha256>be6d3ab404d2bd9ee32c28774068fdc119fc6ee726b3d823728011e028680592</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast develop Editor module to [17.x-2026-06-19](https://github.com/gregorydlogan/opencast-editor/releases/tag/17.x-2026-06-19)