### PR TITLE
Update develop Editor to 18.x-9999-99-99

### DIFF
--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/opencast/opencast-editor/releases/download/17.x-2025-05-23/oc-editor-17.x-2025-05-23.tar.gz</editor.url>
-    <editor.sha256></editor.sha256>
+    <editor.url>https://github.com/gregorydlogan/opencast-editor/releases/download/18.x-9999-99-99/oc-editor-18.x-9999-99-99.tar.gz</editor.url>
+    <editor.sha256>8a6e560a2a7b44def18fd82b2a3c290387a3489b47c9bdd6da24e0cbed808881</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast develop Editor module to [18.x-9999-99-99](https://github.com/gregorydlogan/opencast-editor/releases/tag/18.x-9999-99-99)