### PR TITLE
Update r/17.x Editor to 17.x-9999-99-98

### DIFF
--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/opencast/opencast-editor/releases/download/17.x-2025-05-23/oc-editor-17.x-2025-05-23.tar.gz</editor.url>
-    <editor.sha256></editor.sha256>
+    <editor.url>https://github.com/gregorydlogan/opencast-editor/releases/download/17.x-9999-99-98/oc-editor-17.x-9999-99-98.tar.gz</editor.url>
+    <editor.sha256>0e0e21c7c49ed1acfe74d9208f00f22dbb7707c1ea9032698426f75d9b32c886</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast r/17.x Editor module to [17.x-9999-99-98](https://github.com/gregorydlogan/opencast-editor/releases/tag/17.x-9999-99-98)