### PR TITLE
Update develop Editor to 18.x-2025-06-11

### DIFF
--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/opencast/opencast-editor/releases/download/17.x-2025-05-23/oc-editor-17.x-2025-05-23.tar.gz</editor.url>
-    <editor.sha256></editor.sha256>
+    <editor.url>https://github.com/gregorydlogan/opencast-editor/releases/download/18.x-2025-06-11/oc-editor-18.x-2025-06-11.tar.gz</editor.url>
+    <editor.sha256>5371102280d5877e5aceeaab65977479aac24b5d638a114175ca54cc2e17209b</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast develop Editor module to [18.x-2025-06-11](https://github.com/gregorydlogan/opencast-editor/releases/tag/18.x-2025-06-11)