### PR TITLE
Update develop Admin UI to 18.x-2025-06-19

### DIFF
--- a/modules/admin-ui-interface/pom.xml
+++ b/modules/admin-ui-interface/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/17.x-2025-05-24/oc-admin-ui-17.x-2025-05-24.tar.gz</interface.url>
-    <interface.sha256>9d0438d8d2d158c295c07c9454b80b19127748fb19059988e8cb2d4eb8ce11a7</interface.sha256>
+    <interface.url>https://github.com/gregorydlogan/opencast-admin-interface/releases/download/18.x-2025-06-19/oc-admin-ui-18.x-2025-06-19.tar.gz</interface.url>
+    <interface.sha256>0db1de46ca0a88d296b0b1087aac2f0267a302b2789970982b32260efbcf827c</interface.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast develop Admin UI module to [18.x-2025-06-19](https://github.com/gregorydlogan/opencast-admin-interface/releases/tag/18.x-2025-06-19)