### PR TITLE
Update develop Admin UI to 19.x-2025-11-17

### DIFF
--- a/modules/admin-ui-interface/pom.xml
+++ b/modules/admin-ui-interface/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/18.x-2025-09-29/oc-admin-ui-18.x-2025-09-29.tar.gz</interface.url>
-    <interface.sha256>8a0582011160be35b6da46537c182d6f78bcb5c9293ce4fce057c1f306443e76</interface.sha256>
+    <interface.url>https://github.com/gregorydlogan/opencast-admin-interface/releases/download/19.x-2025-11-17/oc-admin-ui-19.x-2025-11-17.tar.gz</interface.url>
+    <interface.sha256>3a6b260ed401e1678a25b1cbe7e205deb18c8df6c548f53878ee952f6f34db49</interface.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast develop Admin UI module to [19.x-2025-11-17](https://github.com/gregorydlogan/opencast-admin-interface/releases/tag/19.x-2025-11-17)